### PR TITLE
Created custom exceptions

### DIFF
--- a/Eventbrite.php
+++ b/Eventbrite.php
@@ -1,4 +1,30 @@
 <?php
+
+class EventbriteException extends Exception
+{
+    protected $error_type;
+
+    public function __construct($message, $error_type, $code = 0, Exception $previous = null) {
+        $this->error_type = $error_type;
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getType() {
+        return $this->error_type;
+    }
+}
+
+class EventbriteOauthException extends EventbriteException
+{
+
+}
+
+class EventbriteApiException extends EventbriteException
+{
+
+}
+
+
 class Eventbrite {
     /**
      * Eventbrite API endpoint
@@ -68,7 +94,7 @@ class Eventbrite {
 
         $response = get_object_vars(json_decode($json_data));
         if( !array_key_exists('access_token', $response) || array_key_exists('error', $response) ){
-            throw new Exception( $response['error_description'] );
+            throw new EventbriteOauthException( $response['error_description'], $response['error'] );
         }
         return array_merge($tokens, $response);
     }
@@ -106,7 +132,7 @@ class Eventbrite {
             $resp = json_decode( $resp );
 
             if( isset( $resp->error ) && isset($resp->error->error_message) ){
-                throw new Exception( $resp->error->error_message );
+                throw new EventbriteApiException( $resp->error->error_message, $resp->error->error_type );
             }
         }
         return $resp;


### PR DESCRIPTION
Hi,

I have created a pull request to throw custom exceptions so that code like the following is possible:

```
  try {
    $resp = $client->event_search($search_params);
  }
  catch (EventbriteException $e) {
    // Deal with API errors.
  }
  catch (Exception $e) {
    // Deal with generic PHP or connectivity errors here.
  }
```

This makes it possible to deal with errors returned from the Eventbrite API differently to those thrown by other code.

I have put the custom exceptions in the main Eventbrite.php file as it is all currently self-contained there, so let me know if you think they should be in separate file(s) to be required.
